### PR TITLE
Filter out non image attachments from test activity details

### DIFF
--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -27,6 +27,10 @@ export interface Attachment {
   dimensions: Dimensions
 }
 
+export function isImageAttachmentType(uniformTypeIdentifier: string) {
+  return ['public.jpeg', 'public.png'].includes(uniformTypeIdentifier)
+}
+
 export async function exportAttachments(
   parser: Parser,
   activity: Activity
@@ -35,7 +39,7 @@ export async function exportAttachments(
 
   if (activity.attachments) {
     for (const attachment of activity.attachments) {
-      if (attachment.filename && attachment.payloadRef) {
+      if (attachment.filename && attachment.payloadRef && isImageAttachmentType(attachment.uniformTypeIdentifier)) {
         const outputPath = path.join(os.tmpdir(), attachment.filename)
         const image = await parser.exportObject(
           attachment.payloadRef.id,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -39,6 +39,7 @@ import {Activity} from './activity'
 import {Parser} from './parser'
 
 import {exportAttachments} from './attachment'
+import {isImageAttachmentType} from './attachment'
 
 const passedIcon = Image.testStatus('Success')
 const failedIcon = Image.testStatus('Failure')
@@ -673,7 +674,10 @@ export class Formatter {
                 if (activities.length) {
                   const testActivities = activities
                     .map(activity => {
-                      const attachments = activity.attachments.map(
+                      const imageAttachments = activity.attachments.filter(attachment => {
+                        return isImageAttachmentType(attachment.uniformTypeIdentifier)
+                      })
+                      const attachments = imageAttachments.map(
                         attachment => {
                           let width = '100%'
                           const dimensions = attachment.dimensions


### PR DESCRIPTION
As non image attachments are not supported, it is best to filter them
out. Otherwise `exportAttachments` will fail when trying to read image
dimensions at:
```
const dimensions: Dimensions = sizeOf(image)
```
And Formatter will fail to access `dimensions` property on attachment
while constructing `img` for it.