### PR TITLE
ignore __tests__ folder when create a release 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-dist/** -diff linguist-generated=true 
+dist/** -diff linguist-generated=true
+__tests__/** export-ignore

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,7 +169,7 @@ async function mergeResultBundle(
   }
 
   const options = {
-    silent: true
+    silent: false
   }
 
   await exec.exec('xcrun', args, options)

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {Formatter} from './formatter'
 import {Octokit} from '@octokit/action'
 import {glob} from 'glob'
 import {promises} from 'fs'
+import {getXcodeVersion} from './xcode'
 const {stat} = promises
 
 async function run(): Promise<void> {
@@ -157,9 +158,16 @@ async function mergeResultBundle(
   inputPaths: string[],
   outputPath: string
 ): Promise<void> {
+  const xcodeVersion = await getXcodeVersion();
+
   const args = ['xcresulttool', 'merge']
-    .concat(inputPaths)
-    .concat(['--output-path', outputPath])
+  .concat(inputPaths)
+  .concat(['--output-path', outputPath])
+
+  if (xcodeVersion >= 16) {
+    args.push('--legacy');
+  }
+
   const options = {
     silent: true
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -2,6 +2,8 @@
 
 import * as exec from '@actions/exec'
 import {promises} from 'fs'
+import {getXcodeVersion} from './xcode'
+
 const {readFile} = promises
 
 export class Parser {
@@ -17,6 +19,8 @@ export class Parser {
   }
 
   async exportObject(reference: string, outputPath: string): Promise<Buffer> {
+    const xcodeVersion = await getXcodeVersion();
+    
     const args = [
       'xcresulttool',
       'export',
@@ -29,6 +33,11 @@ export class Parser {
       '--id',
       reference
     ]
+
+    if (xcodeVersion >= 16) {
+      args.push('--legacy');
+    }
+    
     const options = {
       silent: true
     }
@@ -55,6 +64,8 @@ export class Parser {
   }
 
   private async toJSON(reference?: string): Promise<string> {
+    const xcodeVersion = await getXcodeVersion();
+    
     const args = [
       'xcresulttool',
       'get',
@@ -68,6 +79,10 @@ export class Parser {
       args.push(reference)
     }
 
+    if (xcodeVersion >= 16) {
+      args.push('--legacy');
+    }
+    
     let output = ''
     const options = {
       silent: true,

--- a/src/xcode.ts
+++ b/src/xcode.ts
@@ -1,0 +1,18 @@
+import * as exec from "@actions/exec";
+
+export async function getXcodeVersion(): Promise<number> {
+    let output = '';
+    const options = {
+        listeners: {
+            stdout: (data: Buffer) => {
+                output += data.toString();
+            }
+        }
+    };
+    await exec.exec('xcodebuild', ['-version'], options);
+    const match = output.match(/Xcode (\d+)/);
+    if (match) {
+        return parseInt(match[1], 10);
+    }
+    throw new Error('Unable to determine Xcode version');
+}


### PR DESCRIPTION
The released tarball is too large, causing frequent download timeouts. The `__tests__/data` directory accounts for 98% of the size. This PR sets `__tests__` as `export-ignore`, so that when creating a release, the tarball will not include the `__tests__` directory.

#709 